### PR TITLE
Remove unloadable from idp_controller

### DIFF
--- a/app/controllers/saml_idp/idp_controller.rb
+++ b/app/controllers/saml_idp/idp_controller.rb
@@ -2,7 +2,7 @@ module SamlIdp
   class IdpController < ActionController::Base
     include SamlIdp::Controller
 
-    unloadable
+    unloadable if Rails.version.to_i < 7
 
     protect_from_forgery
 


### PR DESCRIPTION
ActiveSupport::Dependencies::ModuleConstMissing (where this method was defined) was removed in Rails 7. See:

https://github.com/rails/rails/commit/a7a217212b499187c134822b522b7e4711e22660