### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ezcater/users-core-services


### PR DESCRIPTION
The repository has not been claimed by an engineering team. The proposed code owner is @ezcater/users-core-services according to [GitHub Cleanup](https://docs.google.com/spreadsheets/d/1OjnNxQpvSZNctGDYjc8WeSX4VjVnb_GigB5dH_Q6MJQ/edit?gid=647015428#gid=647015428).